### PR TITLE
improve granularity of printed time

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -71,7 +71,7 @@ req.on('response', function(res){
   var len = parseInt(res.headers['content-length'], 10);
 
   console.log();
-  var bar = new ProgressBar('  downloading [:bar] :percent :etas', {
+  var bar = new ProgressBar('  downloading [:bar] :percent :eta', {
     complete: '=',
     incomplete: ' ',
     width: 20,
@@ -93,7 +93,7 @@ req.end();
 The above example result in a progress bar like the one below.
 
 ```
-downloading [=====             ] 29% 3.7s
+downloading [=====             ] 29% 3s
 ```
 
 You can see more examples in the `examples` folder.

--- a/examples/download.js
+++ b/examples/download.js
@@ -9,7 +9,7 @@ var ProgressBar = require('../');
 
 var contentLength = 128 * 1024;
 
-var bar = new ProgressBar('  downloading [:bar] :percent :etas', {
+var bar = new ProgressBar('  downloading [:bar] :percent :eta', {
     complete: '='
   , incomplete: ' '
   , width: 20

--- a/examples/exact.js
+++ b/examples/exact.js
@@ -8,7 +8,7 @@
 
 var ProgressBar = require('../');
 
-var bar = new ProgressBar('  progress [:bar] :percent :etas', {
+var bar = new ProgressBar('  progress [:bar] :percent :eta', {
     complete: '='
   , incomplete: ' '
   , width: 40

--- a/examples/formats.js
+++ b/examples/formats.js
@@ -64,7 +64,7 @@ function bar4() {
 }
 
 function bar5() {
-  var bar = new ProgressBar('  [:bar] :elapseds elapsed, eta :etas', {
+  var bar = new ProgressBar('  [:bar] :elapsed elapsed, eta :eta', {
       width: 8
     , total: 50
   });

--- a/examples/toolong.js
+++ b/examples/toolong.js
@@ -7,7 +7,7 @@ var ProgressBar = require('../');
 
 // simulated download, passing the chunk lengths to tick()
 
-var bar = new ProgressBar('  downloading [:bar] :percent :etas', {
+var bar = new ProgressBar('  downloading [:bar] :percent :eta', {
     complete: '='
   , incomplete: ' '
   , width: 1024     /* something longer than the terminal width */

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -4,6 +4,8 @@
  * MIT Licensed
  */
 
+var time = require('humanize-time')
+
 /**
  * Expose `ProgressBar`.
  */
@@ -117,9 +119,8 @@ ProgressBar.prototype.render = function (tokens) {
   var str = this.fmt
     .replace(':current', this.curr)
     .replace(':total', this.total)
-    .replace(':elapsed', isNaN(elapsed) ? '0.0' : (elapsed / 1000).toFixed(1))
-    .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : (eta / 1000)
-      .toFixed(1))
+    .replace(':elapsed', isNaN(elapsed) ? '0.0' : time(elapsed))
+    .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : time(eta))
     .replace(':percent', percent.toFixed(0) + '%');
 
   /* compute the available space (non-zero) for the bar */

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
         , "email": "scalesjordan@gmail.com"
       }
   ]
-  , "dependencies": {}
+  , "dependencies": {
+    "humanize-time": "0.0.2"
+  }
   , "main": "index"
   , "engines": { "node": ">=0.4.0" }
   , "repository": "git://github.com/visionmedia/node-progress"


### PR DESCRIPTION
although I appreciate @marceloboeira's efforts in #69, I don't like
how imprecise the printed time becomes.

to demonstrate, this is how `ms` converts miliseconds

``` javascript
var time = require('ms')

time(2000)    // '2s'
time(62000)   // '1m'
time(3662000) // '1h'
```

and this is how `humanize-time` does it

``` javascript
var time = require('humanize-time')

time(2000)    // '2s'
time(62000)   // '1m, 2s'
time(3662000) // '1h, 1m, 2s'
```
