### PR TITLE
make the default formatter overridable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,7 @@ These are keys in the options object you can pass to the progress bar along with
 - `incomplete` incomplete character defaulting to "-"
 - `clear` option to clear the bar on completion defaulting to false
 - `callback` optional function to call when the progress bar completes
+- `formatter` optional function that customizes conversion of tokens to output
 
 ### Tokens
 

--- a/examples/custom-formatter.js
+++ b/examples/custom-formatter.js
@@ -1,0 +1,26 @@
+function seconds(ms){
+  return Math.floor(ms/1000) + " seconds"
+}
+
+var Progress = require('../')
+
+var bar  = new Progress(':bar :percent :elapsed', {
+  total: 100,
+  width: 25,
+  formatter: function(eta, elapsed, percent){
+    return this.fmt
+      .replace(':current', this.curr)
+      .replace(':total', this.total)
+      .replace(':elapsed', isNaN(elapsed) ? '0.0' : seconds(elapsed))
+      .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : (eta / 1000)
+        .toFixed(1))
+      .replace(':percent', percent.toFixed(0) + '%')
+  }
+});
+
+var id = setInterval(function (){
+  bar.tick();
+  if (bar.complete) {
+    clearInterval(id);
+  }
+}, 100);

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -62,6 +62,16 @@ function ProgressBar(fmt, options) {
   };
   this.callback = options.callback || function () {};
   this.lastDraw = '';
+  this.formatter = options.formatter || function (eta, elapsed, percent) {
+    /* populate the bar template with percentages and timestamps */
+    return this.fmt
+      .replace(':current', this.curr)
+      .replace(':total', this.total)
+      .replace(':elapsed', isNaN(elapsed) ? '0.0' : (elapsed / 1000).toFixed(1))
+      .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : (eta / 1000)
+        .toFixed(1))
+      .replace(':percent', percent.toFixed(0) + '%');
+  };
 }
 
 /**
@@ -112,15 +122,7 @@ ProgressBar.prototype.render = function (tokens) {
   var incomplete, complete, completeLength;
   var elapsed = new Date - this.start;
   var eta = (percent == 100) ? 0 : elapsed * (this.total / this.curr - 1);
-
-  /* populate the bar template with percentages and timestamps */
-  var str = this.fmt
-    .replace(':current', this.curr)
-    .replace(':total', this.total)
-    .replace(':elapsed', isNaN(elapsed) ? '0.0' : (elapsed / 1000).toFixed(1))
-    .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : (eta / 1000)
-      .toFixed(1))
-    .replace(':percent', percent.toFixed(0) + '%');
+  var str = this.formatter(eta, elapsed, percent);
 
   /* compute the available space (non-zero) for the bar */
   var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);


### PR DESCRIPTION
simply makes the default formatter overridable, so users can define their own
time formats and customize other tokens
