### PR TITLE
Feat/start

### DIFF
--- a/examples/restart.js
+++ b/examples/restart.js
@@ -1,0 +1,29 @@
+var ProgressBar = require('../');
+
+// Demonstrates reusing the progress bar
+
+var list = ['file1.ext', 'file2.ext', 'file3.ext'];
+
+var bar = new ProgressBar('  loading :filename :percent[:bar] :current/:total', {
+  total: 0, // This value is required, but unused as we'll
+            // be setting it later with bar.start()
+  width: 10
+});
+
+// Loop through list items
+(function next() {
+  if (list.length === 0) return;
+  var file = list.shift();
+  bar.start(parseInt((Math.random() * 100000) + 100000), {'filename': file});
+
+  // loop through chunks
+  (function nextChunk() {
+    var chunk = Math.min(bar.total - bar.curr, parseInt((Math.random() * 20) + 1) * 1024);
+    bar.tick(chunk, {'filename': file});
+    if (!bar.complete) {
+      setTimeout(nextChunk, parseInt((Math.random() * 100) + 1) * 4);
+    } else {
+      next();
+    }
+  })();
+})();

--- a/examples/start.js
+++ b/examples/start.js
@@ -1,0 +1,15 @@
+var ProgressBar = require('../');
+
+// Demonstrates starting the bar before first tick
+
+var bar = new ProgressBar('  [:bar] :elapsed', {
+  total: 10,
+  callback: function() {
+    clearInterval(interval);
+  }
+});
+
+bar.start();
+var interval = setInterval(function (){
+  bar.tick();
+}, 500);

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -68,6 +68,21 @@ function ProgressBar(fmt, options) {
 }
 
 /**
+ * Method to initialize the progress bar with optional `tokens` to pass to
+ * render(). Automatically called on first tick if required.
+ *
+ * @param {object} tokens
+ * @api public
+ */
+
+ProgressBar.prototype.start = function(tokens){
+  this.startTime = new Date;
+  this.curr = 0;
+  this.complete = false;
+  this.render(tokens);
+};
+
+/**
  * "tick" the progress bar with optional `len` and optional `tokens`.
  *
  * @param {number|object} len or tokens
@@ -83,8 +98,8 @@ ProgressBar.prototype.tick = function(len, tokens){
   if ('object' == typeof len) tokens = len, len = 1;
   if (tokens) this.tokens = tokens;
 
-  // start time for eta
-  if (0 == this.curr) this.start = new Date;
+  // initialize progress bar
+  if (!this.startTime) this.start;
 
   this.curr += len
 
@@ -124,7 +139,7 @@ ProgressBar.prototype.render = function (tokens) {
 
   var percent = ratio * 100;
   var incomplete, complete, completeLength;
-  var elapsed = new Date - this.start;
+  var elapsed = new Date - this.startTime;
   var eta = (percent == 100) ? 0 : elapsed * (this.total / this.curr - 1);
 
   /* populate the bar template with percentages and timestamps */

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -67,15 +67,26 @@ function ProgressBar(fmt, options) {
 }
 
 /**
- * Method to initialize the progress bar with optional `tokens` to pass to
- * render(). Automatically called on first tick if required.
+ * Method to initialize the progress bar with optional `total` and optional
+ * `tokens` to pass to render().
+ * Automatically called on first tick if required.
  *
+ * @param {number|object} total or tokens
  * @param {object} tokens
  * @api public
  */
 
-ProgressBar.prototype.start = function(tokens){
+ProgressBar.prototype.start = function(total, tokens){
+  // swap tokens
+  if ('object' == typeof total) tokens = total, total = null
+
+  // update total
+  if (total) this.total = total;
+
+  // start time for eta
   this.startTime = new Date;
+
+  // initialize/reset bar
   this.curr = 0;
   this.complete = false;
   this.render(tokens);

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -53,7 +53,6 @@ function ProgressBar(fmt, options) {
   }
 
   this.fmt = fmt;
-  this.curr = 0;
   this.total = options.total;
   this.width = options.width || this.total;
   this.clear = options.clear


### PR DESCRIPTION
Fixes #81 

@jdan what are your thoughts on this?

I would have expected that doing a `bar.tick(0)` after creating the ProgressBar instance would 'start' the bar and have fixed the issue, but because of `if (0 == this.curr) this.start = new Date` the start time is reset once the next `bar.tick()` is called.

Issue #81 could be fixed by changing to `if (!this.start) this.start = new Date`, but that could possibly break things as the start time would never reset if the bar were reset (do users even do that?).

As such, I had the idea to implement an new `start()` method to better define the functionality instead of trying to use `tick(0)`. I then expanded upon the concept to allow users to use the `start()` method to reset the bar for reuse rather than recreating the entire thing (example: downloading multiple files in series).

This will still break things if users are relying on the elapsed time to reset when running `update(0)`, for example, however, this implementation provides a clear replacement for users that want that functionality (use `start()` instead of `update(0)`)
