### PR TITLE
Add a method to log a message more conveniently while still in the middle of displaying the progress bar

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -4,6 +4,8 @@
  * MIT Licensed
  */
 
+var util = require('util');
+
 /**
  * Expose `ProgressBar`.
  */
@@ -191,4 +193,17 @@ ProgressBar.prototype.terminate = function () {
     this.stream.clearLine();
     this.stream.cursorTo(0);
   } else this.stream.write('\n');
+};
+
+/**
+ * Logs a message. Accepts the same arguments as util.format.
+ * @param {string} message The message to log
+ * @api public
+ */
+
+ProgressBar.prototype.log = function () {
+  this.stream.clearLine();
+  this.stream.cursorTo(0);
+  this.stream.write(util.format.apply(util, arguments)+'\n');
+  this.stream.write(this.lastDraw);
 };

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -202,8 +202,12 @@ ProgressBar.prototype.terminate = function () {
  */
 
 ProgressBar.prototype.log = function () {
-  this.stream.clearLine();
-  this.stream.cursorTo(0);
+  if (this.stream.isTTY) {
+    this.stream.clearLine();
+    this.stream.cursorTo(0);
+  }
   this.stream.write(util.format.apply(util, arguments)+'\n');
-  this.stream.write(this.lastDraw);
+  if (this.stream.isTTY) {
+    this.stream.write(this.lastDraw);
+  }
 };


### PR DESCRIPTION
`bar.log('foo')` will output to the same stream as the progress bar is outputting to, but it will essentially print a line "above" the current progress bar readout.
