### PR TITLE
Handle multiline `fmt`-s

### DIFF
--- a/examples/multiline.js
+++ b/examples/multiline.js
@@ -1,0 +1,32 @@
+var ProgressBar = require('../index');
+
+var bar = new ProgressBar("Bar:\t:bar [:current/:total]\n:random\nTime:\t:elapsed s", {
+	width: 10,
+	total: 100,
+	tokens: {random: 'First call'}
+});
+
+console.log('A visible line');
+
+var count = 0;
+var tickId = setInterval(tick, 20);
+
+function tick() {
+	if(count === 99) {
+		bar.terminate();
+		clearInterval(tickId);
+
+		setTimeout(console.log.bind(console, '\nDone!'), 21);
+	}
+
+	var bgColor = '\u001b[' + (40 + (Math.random() * 7) | 0) + 'm';
+	var fgColor = '\u001b[' + (30 + (Math.random() * 7) | 0) + 'm';
+	var end     = '\u001b[m';
+
+	var text = Math.random().toString(36).substr((Math.random() * 13) | 0);
+
+	bar.tokens.random = 'Text:\t' + bgColor + fgColor + text + end;
+
+	bar.tick();
+	count++;
+}

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -64,7 +64,7 @@ function ProgressBar(fmt, options) {
   this.renderThrottle = options.renderThrottle !== 0 ? (options.renderThrottle || 16) : 0;
   this.callback = options.callback || function () {};
   this.tokens = {};
-  this.lastDraw = '';
+  this.lastDraw = null;
 }
 
 /**
@@ -152,8 +152,23 @@ ProgressBar.prototype.render = function (tokens) {
   if (this.tokens) for (var key in this.tokens) str = str.replace(':' + key, this.tokens[key]);
 
   if (this.lastDraw !== str) {
+
+    if(this.lastDraw == null) {
+      this.stream.write('\r');
+    }
+
+    var lines = str.split('\n');
+    this.stream.write('\033[' + lines.length + 'A\r');
+    for(var i = 0, len = lines.length - 1; i < len; i++) {
+
+      this.stream.cursorTo(0);
+      this.stream.write(lines[i] + '\r');
+      this.stream.clearLine(1);
+
+    }
+
     this.stream.cursorTo(0);
-    this.stream.write(str);
+    this.stream.write(lines[len]);
     this.stream.clearLine(1);
     this.lastDraw = str;
   }


### PR DESCRIPTION
There was a serious problem when using format strings with `\n` in them. In the example given, I use the string:

```
Bar:    :bar [:current/:total]
:random
Time:   :elapsed s
```

Where the `random` token is a random string with length that varies on each tick.
**Expected output**
![expected](https://cloud.githubusercontent.com/assets/3787795/9270940/5c8be576-427e-11e5-8303-036b74f80771.gif)

**Actual output**
![actual](https://cloud.githubusercontent.com/assets/3787795/9270954/731f0b92-427e-11e5-9c24-f88f928a35e6.gif)

This patch aims to address and fix this issue.
