### PR TITLE
Ability to format tick number in progress bar

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,7 @@ These are keys in the options object you can pass to the progress bar along with
 - `incomplete` incomplete character defaulting to "-"
 - `renderThrottle` minimum time between updates in milliseconds defaulting to 16
 - `clear` option to clear the bar on completion defaulting to false
+- `format` optional function to format tick numbers
 - `callback` optional function to call when the progress bar completes
 
 ### Tokens

--- a/Readme.md
+++ b/Readme.md
@@ -80,10 +80,12 @@ The above example would result in the output below.
 In our download example each tick has a variable influence, so we pass the chunk
 length which adjusts the progress bar appropriately relative to the total
 length.
+`bytes` module is used to format tick numbers to human-readable file sizes.
 
 ```javascript
 var ProgressBar = require('../');
 var https = require('https');
+var bytes = require('bytes');
 
 var req = https.request({
   host: 'download.github.com',
@@ -95,9 +97,10 @@ req.on('response', function(res){
   var len = parseInt(res.headers['content-length'], 10);
 
   console.log();
-  var bar = new ProgressBar('  downloading [:bar] :percent :etas', {
+  var bar = new ProgressBar('  downloading [:bar] :percent :current/:total :etas', {
     complete: '=',
     incomplete: ' ',
+    format: bytes,
     width: 20,
     total: len
   });
@@ -117,7 +120,7 @@ req.end();
 The above example result in a progress bar like the one below.
 
 ```
-downloading [=====             ] 29% 3.7s
+downloading [=====             ] 29% 2.70kB/9.31kB 3.7s
 ```
 
 You can see more examples in the `examples` folder.

--- a/examples/format.js
+++ b/examples/format.js
@@ -1,0 +1,19 @@
+var Progress = require('../')
+
+var contentLength = 15000 * 1024;
+
+var bar = new Progress('  downloading [:bar] :current/:total', {
+  total: contentLength,
+  format: function (bytes) {
+    var value = Math.round(bytes / (1 << 20) * 100) / 100;
+    return value + 'MB';
+  }
+});
+
+var id = setInterval(function() {
+  var chunk = Math.random() * 1000 * 1024;
+  bar.tick(chunk);
+  if (bar.complete) {
+    clearInterval(id);
+  }
+}, 100);

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -62,6 +62,7 @@ function ProgressBar(fmt, options) {
     incomplete : options.incomplete || '-'
   };
   this.renderThrottle = options.renderThrottle !== 0 ? (options.renderThrottle || 16) : 0;
+  this.format = options.format;
   this.callback = options.callback || function () {};
   this.tokens = {};
   this.lastDraw = '';
@@ -129,8 +130,8 @@ ProgressBar.prototype.render = function (tokens) {
 
   /* populate the bar template with percentages and timestamps */
   var str = this.fmt
-    .replace(':current', this.curr)
-    .replace(':total', this.total)
+    .replace(':current', this.format ? this.format(this.curr) : this.curr)
+    .replace(':total', this.format ? this.format(this.total) : this.total)
     .replace(':elapsed', isNaN(elapsed) ? '0.0' : (elapsed / 1000).toFixed(1))
     .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : (eta / 1000)
       .toFixed(1))


### PR DESCRIPTION
The main use-case is to format number of downloaded bytes into human-readable strings:

``` js
var ProgressBar = require('../');
var https = require('https');
var bytes = require('bytes');

var req = https.request({
  host: 'download.github.com',
  port: 443,
  path: '/visionmedia-node-jscoverage-0d4608a.zip'
});

req.on('response', function(res){
  var len = parseInt(res.headers['content-length'], 10);

  console.log();
  var bar = new ProgressBar('  downloading [:bar] :percent :current/:total :etas', {
    complete: '=',
    incomplete: ' ',
    format: bytes,
    width: 20,
    total: len
  });

  res.on('data', function (chunk) {
    bar.tick(chunk.length);
  });

  res.on('end', function () {
    console.log('\n');
  });
});

req.end();
```

Here is how it'll look:

```
downloading [=====             ] 29% 2.70kB/9.31kB 3.7s
```
