### PR TITLE
Add rate reporting to progress bar

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,7 @@ These are tokens you can use in the format of your progress bar.
 - `:elapsed` time elapsed in seconds
 - `:percent` completion percentage
 - `:eta` estimated completion time in seconds
+- `:rate` rate of ticks per second
 
 ### Custom Tokens
 
@@ -94,7 +95,7 @@ req.on('response', function(res){
   var len = parseInt(res.headers['content-length'], 10);
 
   console.log();
-  var bar = new ProgressBar('  downloading [:bar] :percent :etas', {
+  var bar = new ProgressBar('  downloading [:bar] :rate/bps :percent :etas', {
     complete: '=',
     incomplete: ' ',
     width: 20,
@@ -116,7 +117,7 @@ req.end();
 The above example result in a progress bar like the one below.
 
 ```
-downloading [=====             ] 29% 3.7s
+downloading [=====             ] 39/bps 29% 3.7s
 ```
 
 You can see more examples in the `examples` folder.

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -33,6 +33,7 @@ exports = module.exports = ProgressBar;
  *   - `:elapsed` time elapsed in seconds
  *   - `:percent` completion percentage
  *   - `:eta` eta in seconds
+ *   - `:rate` rate of ticks per second
  *
  * @param {string} fmt
  * @param {object|number} options or total
@@ -126,6 +127,7 @@ ProgressBar.prototype.render = function (tokens) {
   var incomplete, complete, completeLength;
   var elapsed = new Date - this.start;
   var eta = (percent == 100) ? 0 : elapsed * (this.total / this.curr - 1);
+  var rate = this.curr / (elapsed / 1000);
 
   /* populate the bar template with percentages and timestamps */
   var str = this.fmt
@@ -134,7 +136,8 @@ ProgressBar.prototype.render = function (tokens) {
     .replace(':elapsed', isNaN(elapsed) ? '0.0' : (elapsed / 1000).toFixed(1))
     .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : (eta / 1000)
       .toFixed(1))
-    .replace(':percent', percent.toFixed(0) + '%');
+    .replace(':percent', percent.toFixed(0) + '%')
+    .replace(':rate', Math.round(rate));
 
   /* compute the available space (non-zero) for the bar */
   var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "progress"
-  , "version": "1.1.8"
+  , "version": "1.2.0"
   , "description": "Flexible ascii progress bar"
   , "keywords": ["cli", "progress"]
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "progress"
-  , "version": "1.2.0"
+  , "version": "1.1.8"
   , "description": "Flexible ascii progress bar"
   , "keywords": ["cli", "progress"]
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"


### PR DESCRIPTION
I have been working on several progress bars where I would like to show the rate of completion.

I did not see a simple way to accomplish this so I created a small patch to show this option.

I have updated the README and tested this in my instances. It works without issue.

Just add `:rate` anywhere in a progress bar to get the rate in ticks per second. This is useful for working with download bars. I added an example in the download bar for the main README.md

Finally, I bumped the version to 1.2.0 as it seems worthy of a feature bump.

Please let me know if anything else is needed to merge this request.

Thank you!
