### PR TITLE
fixed output multiline on windows cmd

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -137,7 +137,11 @@ ProgressBar.prototype.render = function (tokens) {
     .replace(':percent', percent.toFixed(0) + '%');
 
   /* compute the available space (non-zero) for the bar */
-  var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length - 1);
+  var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);
+  if(availableSpace && process.platform === 'win32'){
+    availableSpace = availableSpace - 1; 
+  }
+  
   var width = Math.min(this.width, availableSpace);
 
   /* TODO: the following assumes the user has one ':bar' token */

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -137,7 +137,7 @@ ProgressBar.prototype.render = function (tokens) {
     .replace(':percent', percent.toFixed(0) + '%');
 
   /* compute the available space (non-zero) for the bar */
-  var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);
+  var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length - 1);
   var width = Math.min(this.width, availableSpace);
 
   /* TODO: the following assumes the user has one ':bar' token */


### PR DESCRIPTION
Windows `cmd` will auto change line when the output `str`'s length equals `cmd`'s columns
so I let `availableSpace` -1 to avoid auto change line on Windows `cmd`.
