### PR TITLE
Prevent auto-writing to stream

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -65,6 +65,7 @@ function ProgressBar(fmt, options) {
   this.callback = options.callback || function () {};
   this.tokens = {};
   this.lastDraw = '';
+  this.print = options.print !== false;
 }
 
 /**
@@ -152,9 +153,11 @@ ProgressBar.prototype.render = function (tokens) {
   if (this.tokens) for (var key in this.tokens) str = str.replace(':' + key, this.tokens[key]);
 
   if (this.lastDraw !== str) {
-    this.stream.cursorTo(0);
-    this.stream.write(str);
-    this.stream.clearLine(1);
+    if (this.print) {
+      this.stream.cursorTo(0);
+      this.stream.write(str);
+      this.stream.clearLine(1);
+    }
     this.lastDraw = str;
   }
 };
@@ -187,8 +190,10 @@ ProgressBar.prototype.update = function (ratio, tokens) {
  */
 
 ProgressBar.prototype.terminate = function () {
-  if (this.clear) {
-    this.stream.clearLine();
-    this.stream.cursorTo(0);
-  } else this.stream.write('\n');
+  if (this.print) {
+    if (this.clear) {
+      this.stream.clearLine();
+      this.stream.cursorTo(0);
+    } else this.stream.write('\n');
+  }
 };


### PR DESCRIPTION
This adds the option `print` that if set to false will prevent the code from writing to the stream. This is useful when the user wants to display or use the generated string in other ways, i.e., to use the `log-update` package (https://github.com/sindresorhus/log-update) to output multiple lines of updating information. The user can still access the generated bar via the `lastDraw` parameter.
