### PR TITLE
Fixes NaN Error in Render

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -119,7 +119,7 @@ ProgressBar.prototype.render = function (tokens) {
 
   if (!this.stream.isTTY) return;
 
-  var ratio = this.curr / this.total;
+  var ratio = this.curr / this.total || 0;
   ratio = Math.min(Math.max(ratio, 0), 1);
 
   var percent = ratio * 100;


### PR DESCRIPTION
Currently if render is called with `curr = 0` and `total = 0` it evaluates as `0/0 = NaN` which causes cascading type errors in the function.

This patch adds a 0 value for ratio if it currently not calculable, preventing additional errors.
