### PR TITLE
Fix Array length when window its to small

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -145,8 +145,8 @@ ProgressBar.prototype.render = function (tokens) {
 
   /* TODO: the following assumes the user has one ':bar' token */
   completeLength = Math.round(width * ratio);
-  complete = Array(completeLength + 1).join(this.chars.complete);
-  incomplete = Array(width - completeLength + 1).join(this.chars.incomplete);
+  complete = Array(Math.max(0, completeLength + 1)).join(this.chars.complete);
+  incomplete = Array(Math.max(0, width - completeLength + 1)).join(this.chars.incomplete);
 
   /* fill in the actual progress bar */
   str = str.replace(':bar', complete + incomplete);


### PR DESCRIPTION
Uses a minimum valid value for creating array instances, fixes #130 and [#283](https://github.com/lerna/lerna/issues/283)(from [Lerna project](https://github.com/lerna/lerna)).

Thanks @thejameskyle for [the inspiration](https://github.com/visionmedia/node-progress/issues/130#issuecomment-234343447) and you guys for the library 🚀 