### PR TITLE
Check if is not TTY stream in terminate method

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -145,9 +145,9 @@ ProgressBar.prototype.render = function (tokens) {
   /* compute the available space (non-zero) for the bar */
   var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);
   if(availableSpace && process.platform === 'win32'){
-    availableSpace = availableSpace - 1; 
+    availableSpace = availableSpace - 1;
   }
-  
+
   var width = Math.min(this.width, availableSpace);
 
   /* TODO: the following assumes the user has one ':bar' token */
@@ -220,6 +220,8 @@ ProgressBar.prototype.interrupt = function (message) {
  */
 
 ProgressBar.prototype.terminate = function () {
+  if (!this.stream.isTTY) return;
+
   if (this.clear) {
     this.stream.clearLine();
     this.stream.cursorTo(0);


### PR DESCRIPTION
Without this check terminate method throws "this.stream.clearLine is not a function" exception when "clear" option is enabled on non TTY.