### PR TITLE
Prevent terminate to clearLine for non-TTY stream

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -220,7 +220,7 @@ ProgressBar.prototype.interrupt = function (message) {
  */
 
 ProgressBar.prototype.terminate = function () {
-  if (this.clear) {
+  if (this.clear && this.stream.isTTY) {
     this.stream.clearLine();
     this.stream.cursorTo(0);
   } else {


### PR DESCRIPTION
`ProgressBar.prototype.terminate` does not check if stream is a tty before applying `this.stream.clearLine` method