### PR TITLE
Math.floor percent

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -126,7 +126,7 @@ ProgressBar.prototype.render = function (tokens) {
   var ratio = this.curr / this.total;
   ratio = Math.min(Math.max(ratio, 0), 1);
 
-  var percent = ratio * 100;
+  var percent = Math.floor(ratio * 100);
   var incomplete, complete, completeLength;
   var elapsed = new Date - this.start;
   var eta = (percent == 100) ? 0 : elapsed * (this.total / this.curr - 1);


### PR DESCRIPTION
I've added `Math.floor` to percent in the renderer, so it is more accurate. The bar will then show 1% when eg. 2/2000 is complete.
Before it would say 1% at 1/2000, because it rounded to nearest integer.

Not much - just something my OCD needed to fix.

Thanks for nice little library!