### PR TITLE
fix(clear): check before using stream.clearLine, fixes #95

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -145,9 +145,9 @@ ProgressBar.prototype.render = function (tokens) {
   /* compute the available space (non-zero) for the bar */
   var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);
   if(availableSpace && process.platform === 'win32'){
-    availableSpace = availableSpace - 1; 
+    availableSpace = availableSpace - 1;
   }
-  
+
   var width = Math.min(this.width, availableSpace);
 
   /* TODO: the following assumes the user has one ':bar' token */
@@ -221,8 +221,10 @@ ProgressBar.prototype.interrupt = function (message) {
 
 ProgressBar.prototype.terminate = function () {
   if (this.clear) {
-    this.stream.clearLine();
-    this.stream.cursorTo(0);
+    if (this.stream.clearLine) {
+      this.stream.clearLine();
+      this.stream.cursorTo(0);
+    }
   } else {
     this.stream.write('\n');
   }


### PR DESCRIPTION
For example in new Docker containers the stream does not have `clearLine`