### PR TITLE
"total" validation for NaN format

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -52,7 +52,10 @@ function ProgressBar(fmt, options) {
   } else {
     options = options || {};
     if ('string' != typeof fmt) throw new Error('format required');
-    if ('number' != typeof options.total) throw new Error('total required');
+    if (
+      'number' != typeof options.total
+      || isNaN(options.total)
+    ) throw new Error('total of number format required');
   }
 
   this.fmt = fmt;


### PR DESCRIPTION
Found some cases when `total` attribute may not be defined as `Number/String/undefined`, but could be a `NaN` format implicitly or not.

For example, my app using `node-progress` lib and has no request validation for incoming data `Content-Length` attribute.
But it was actually passed into `const total = parseInt(contentLength, 10)` as `undefined`.
And `total` has taken `NaN`.

Eventually, it throws the errors like described in #166:
```
complete = Array(Math.max(0, completeLength + 1)).join(this.chars.complete);
             ^

RangeError: Invalid array length
    at ProgressBar.render (.../node_modules/progress/lib/node-progress.js:155:14)
    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
```
where `completeLength` takes `NaN` from `total`.

Perhaps it could be more convenient to track if we missed a real `total` value transmitted if it throws when constructor of `ProgressBar` called.

I will be grateful if someone responds to this. Thanks.