### PR TITLE
Use timestamp-based approach for render throttle. Fixes #170.

### DIFF
--- a/examples/iterative.js
+++ b/examples/iterative.js
@@ -6,7 +6,7 @@
 var ProgressBar = require('../');
 
 var len = 10000000; // Adjust to your machine's speed
-var bar = new ProgressBar('[:bar]', len);
+var bar = new ProgressBar('[:bar]', {total: len, renderThrottle: 100});
 
 for (var i = 0; i <= len; i++) {
   bar.tick();

--- a/examples/iterative.js
+++ b/examples/iterative.js
@@ -1,0 +1,13 @@
+/**
+ * A simple progressbar with synchronous calls to tick()
+ * (i.e. no setTimeout/setInterval)
+ */
+
+var ProgressBar = require('../');
+
+var len = 10000000; // Adjust to your machine's speed
+var bar = new ProgressBar('[:bar]', len);
+
+for (var i = 0; i <= len; i++) {
+  bar.tick();
+}

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -93,15 +93,11 @@ ProgressBar.prototype.tick = function(len, tokens){
   this.curr += len
 
   // schedule render
-  if (this.renderThrottle === 0) {
-    this.render();
-  } else if (!this.renderThrottleTimeout) {
-    this.renderThrottleTimeout = setTimeout(this.render.bind(this), this.renderThrottle);
-  }
+  this.render();
 
   // progress complete
   if (this.curr >= this.total) {
-    if (this.renderThrottleTimeout) this.render();
+    this.render();
     this.complete = true;
     this.terminate();
     this.callback(this);

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -114,9 +114,6 @@ ProgressBar.prototype.tick = function(len, tokens){
  */
 
 ProgressBar.prototype.render = function (tokens) {
-  clearTimeout(this.renderThrottleTimeout);
-  this.renderThrottleTimeout = null;
-
   if (tokens) this.tokens = tokens;
 
   if (!this.stream.isTTY) return;

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -66,6 +66,7 @@ function ProgressBar(fmt, options) {
     head       : options.head || (options.complete || '=')
   };
   this.renderThrottle = options.renderThrottle !== 0 ? (options.renderThrottle || 16) : 0;
+  this.lastRender = -Infinity;
   this.callback = options.callback || function () {};
   this.tokens = {};
   this.lastDraw = '';
@@ -92,7 +93,7 @@ ProgressBar.prototype.tick = function(len, tokens){
 
   this.curr += len
 
-  // schedule render
+  // try to render
   this.render();
 
   // progress complete
@@ -117,6 +118,14 @@ ProgressBar.prototype.render = function (tokens) {
   if (tokens) this.tokens = tokens;
 
   if (!this.stream.isTTY) return;
+
+  var now = Date.now();
+  var delta = now - this.lastRender;
+  if (delta < this.renderThrottle) {
+    return;
+  } else {
+    this.lastRender = now;
+  }
 
   var ratio = this.curr / this.total;
   ratio = Math.min(Math.max(ratio, 0), 1);


### PR DESCRIPTION
Adds an example that calls `tick()` synchronously in a loop instead of with `setTimeout`. Replaces the render throttle logic with an approach that, in each `render()` call, compares the delta to the previous actual run to the `renderThrottle` time to decide weather to actually render or not. The API remains untouched, only internal changes.