### PR TITLE
Remove default param from render

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -114,7 +114,8 @@ ProgressBar.prototype.tick = function(len, tokens){
  * @api public
  */
 
-ProgressBar.prototype.render = function (tokens, force = false) {
+ProgressBar.prototype.render = function (tokens, force) {
+  force = force !== undefined ? force : false;
   if (tokens) this.tokens = tokens;
 
   if (!this.stream.isTTY) return;


### PR DESCRIPTION
Fix for #185. Don't use new-style default parameter to maintain backwards compatibility w/ Node 4 & earlier.